### PR TITLE
Fix issue #6 - build error "identifier not defined" 

### DIFF
--- a/HookLib/HookLib/HookLib.h
+++ b/HookLib/HookLib/HookLib.h
@@ -57,7 +57,7 @@ private:
     BOOLEAN m_State;
 public:
     inline T GetOriginal() const {
-        return _Original;
+        return m_Original;
     }
     __declspec(property(get = GetOriginal)) T Original;
     
@@ -79,7 +79,7 @@ public:
 
     BOOLEAN ReinitTarget(T Target) {
         if (!Target) return FALSE;
-        if (_State) return FALSE;
+        if (m_State) return FALSE;
         m_Target = Target;
         return TRUE;
     }


### PR DESCRIPTION
This PR is for fixing issue https://github.com/HoShiMin/HookLib/issues/6

---
Hi, Александр,
I just **downloaded** your code (NOT git clone) and try to build the solution.
However, the compiler complained
```
C3861- '_Original' :  identifier is not defined
C3861- '_State' :  identifier is not defined
```
In file [HookLib.h](https://github.com/HoShiMin/HookLib/blob/master/HookLib/HookLib/HookLib.h)

I believed the the [line 60](https://github.com/HoShiMin/HookLib/blob/master/HookLib/HookLib/HookLib.h#L60)
```
        return _Original;
```
should be
```
        return m_Original;
```
and [line 82](https://github.com/HoShiMin/HookLib/blob/master/HookLib/HookLib/HookLib.h#L82)
```
        if (_State) return FALSE;
```
should be 
```
        if (m_State) return FALSE;
```

After I corrected `_Original` to `m_Original` and `_State` to `m_State`, the project was built successfully.

Seems that This issue was introduced by commit
https://github.com/HoShiMin/HookLib/commit/4576e4300281093626d7a5e493d8e2f3e31525b9

Could you please verify whether this PR could solve this problem? Thanks!