### PR TITLE
include <windows.h> to fix undefined identifier

### DIFF
--- a/HookLib/HookLib/HookLib.h
+++ b/HookLib/HookLib/HookLib.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <windef.h>
+
 #ifdef __cplusplus
 #define HOOKLIB_EXPORT extern "C"
 #else


### PR DESCRIPTION
Hi, Александр,
I'm using your library in my code. I think it is powerful and easy to use : )

But I found that the `HookLib.h` uses macros defined in windows headers such as `HMODULE`, `PVOID`, etc. without `#include <windows.h>`

In this case, If I  `#include HookLib.h` in my project, the VS intellisense will complains `undefined identifier`.
![2](https://user-images.githubusercontent.com/51704722/87214332-05cec300-c35e-11ea-8588-6a1cea21322c.PNG)



If I `#include "HookLib.h"` before `#include <windows.h>`, the compiler will complains "E0020 undefined identifier" as well.

Thus, I think it would be better if we add  `#include <windows.h>` to `HookLib.h`

Best regards,
Rumia